### PR TITLE
Implement Multi-date Work From Home Request Feature

### DIFF
--- a/Date_picker.py
+++ b/Date_picker.py
@@ -1,5 +1,6 @@
 from calendar import Calendar
 import datetime
+from datetime import datetime
 from tkinter import *
 from tkinter import ttk
 from tkinter.ttk import Style
@@ -24,13 +25,11 @@ class DatePicker:
                                  normalbackground ="#353935",
                                  foreground="#F5F5F5",
                                  normalforeground="#F5F5F5",
-                                 selectbackground="red",
-                                 selectforeground="yellow",
                                  borderwidth=0, 
                                  bg_selected='red',
                                 disabledforeground="red",
                                 style="Custom.TCalendarDay")
-        
+
         self.selected_dates = set()
         self.label = Label(self.root, text = "")
         self.successful_dates = []
@@ -82,20 +81,24 @@ class DatePicker:
             if self.successful_dates:
                 successful_dates_str = ', '.join(self.successful_dates)
                 self.label.config(text=f'Work from home successfully requested on {successful_dates_str}')
-                self.label.after(30000, lambda: self.clear_dates())
+                self.label.after(10000, lambda: self.clear_dates())
 
     def clear_dates(self):
         self.label.config(text='')
         self.successful_dates = []
 
     def select_date(self, event):
-        # clicked_date = self.calendar.selection_get()
-        # self.calendar.tag_config(clicked_date, background='red', foreground='yellow')
-        selected_date = self.calendar.selection_get().strftime("%d-%m-%Y")
+        selected_date = self.calendar.selection_get().strftime("%Y-%m-%d")
+        selected_date_format = datetime.strptime(selected_date, "%Y-%m-%d").date()
         if selected_date in self.selected_dates:
             self.selected_dates.remove(selected_date)
+            self.calendar.calevent_remove(selected_date_format)
+            self.calendar.tag_delete(selected_date)
         else: 
             self.selected_dates.add(selected_date)
+            self.calendar.calevent_create(selected_date_format, 'Selected already', selected_date)
+            self.calendar.tag_config(selected_date, background='red', foreground='yellow')
+        print(f"Selected Dates: {self.selected_dates}")
 
     def get_selected_dates(self):
         print("Selected Dates:", self.selected_dates)

--- a/Date_picker.py
+++ b/Date_picker.py
@@ -1,3 +1,4 @@
+from calendar import Calendar
 from tkinter import *
 from tkcalendar import *
 from requests import Session, exceptions
@@ -7,9 +8,13 @@ class DatePicker:
     def __init__(self, session: Session) -> None:
         self.root = Tk()
         self.root.title("citrusHR")
-        self.calendar = Calendar(self.root, selectmode='day')
+        self.calendar = Calendar(self.root, selectmode='day', selectmultiple=True)
+        self.selected_dates = []
         self.label = Label(self.root, text = "")
+        self.successful_dates = []
         self.session = session
+        self.calendar.bind('<<CalendarSelected>>', self.select_date) 
+        self.date_listbox = Listbox(self.root, selectmode=MULTIPLE)
 
     def render(self):
         self.calendar.pack(pady=20)
@@ -18,36 +23,56 @@ class DatePicker:
         Button(self.root, text = "Request WFH", command = self.request_wfh).pack(pady = 10)
         Button(self.root, text = "Quit", command = self.quit).pack(pady = 10)
         self.label.pack(pady = 20)
+        self.date_listbox.pack(pady=10)
 
-        # Execute Tkinter
         self.root.mainloop()
         
     def request_wfh(self):
-        url = f'https://system.citrushr.com/LocationBooking/CreateHome?userId={self.session.headers.get('user_id')}'
+        user_id = self.session.headers.get('user_id')
+        print(f"User ID: {user_id}")
+        
+        cur_selection = self.date_listbox.curselection()
+        print("Current selection:", cur_selection)
+        
+        for index in cur_selection:
+            selected_date = self.date_listbox.get(index)
+            print(f"Selected Date: {selected_date}")
+            
+            url = f'https://system.citrushr.com/LocationBooking/CreateHome?userId={user_id}'
+            payload = {
+                'Startdate': selected_date,
+                'StartPoint': 'StartOfDay',
+                'StartDateHours': '',
+                'EndDate': selected_date,
+                'EndPoint': 'EndOfDay',
+                'EndDateHours': '',
+                'SingleDayPeriod': 'AllDay',
+                'SingleDayHours': '',
+                'Details': ''
+            }
+
+            try:
+                response = self.session.post(url, data=payload)
+                print(f"Response status code: {response.status_code}")  
+
+                if response.status_code == 200:
+                    self.successful_dates.append(selected_date)
+            except exceptions.RequestException as e:
+                self.label.config(text=f'An https error occurred. Please try again')
+            except Exception as e:
+                self.label.config(text=f'Request failed with error: {e}')
+            
+            if self.successful_dates:
+                successful_dates_str = ', '.join(self.successful_dates)
+                self.label.config(text=f'Work from home successfully requested on {successful_dates_str}')
+
+    def select_date(self, event):
         selected_date = self.calendar.selection_get().strftime("%Y-%m-%d")
-
-        payload = {
-            'Startdate': selected_date,
-            'StartPoint': 'StartOfDay',
-            'StartDateHours': '',
-            'EndDate': selected_date,
-            'EndPoint': 'EndOfDay',
-            'EndDateHours': '',
-            'SingleDayPeriod': 'AllDay',
-            'SingleDayHours': '',
-            'Details': ''
-        }
-
-        try:
-            response = self.session.post(url, data=payload)
-
-            if response.status_code == 200:
-                self.label.config(text=f'Work from home successfully request on {selected_date}')
-        except exceptions.RequestException as e:
-            self.label.config(text=f'An https error occurred. Please try again')
-        except Exception as e:
-            self.label.config(text=f'Request failed with error: {e}')
-
+        if selected_date not in self.selected_dates:
+            self.selected_dates.append(selected_date)
+            self.label.config(text=f"Selected dates: {', '.join(self.selected_dates)}")
+            self.date_listbox.insert(END, selected_date)
+        else:
+            self.label.config(text=f"Date already selected: {selected_date}")
     def quit(self):
         self.root.destroy()
-        

--- a/Date_picker.py
+++ b/Date_picker.py
@@ -1,8 +1,6 @@
 from calendar import Calendar
-import datetime
-from datetime import datetime
+from datetime import datetime, date
 from tkinter import *
-from tkinter import ttk
 from tkinter.ttk import Style
 from tkcalendar import *
 from requests import Session, exceptions
@@ -41,7 +39,6 @@ class DatePicker:
         
         # Pack buttons and label
         Button(self.root, text = "Request WFH", command = self.request_wfh).pack(pady = 10)
-        Button(self.root, text="Get Selected Dates", command=self.get_selected_dates).pack(pady=10)
         Button(self.root, text="Clear Selection", command=self.clear_selection).pack(pady=10)
         Button(self.root, text = "Quit", command = self.quit).pack(pady = 10)
         self.label.pack(pady = 20)
@@ -100,13 +97,11 @@ class DatePicker:
             self.calendar.tag_config(selected_date, background='red', foreground='yellow')
         print(f"Selected Dates: {self.selected_dates}")
 
-    def get_selected_dates(self):
-        print("Selected Dates:", self.selected_dates)
-
     def clear_selection(self):
+        for selected_date in self.selected_dates:
+            self.calendar.tag_delete(selected_date)
         self.selected_dates.clear()
-        today_date = datetime.date.today()
-        print(f"Today's date: {today_date}")  
+        today_date = date.today() 
         self.calendar.selection_set(today_date)
 
     def quit(self):

--- a/Date_picker.py
+++ b/Date_picker.py
@@ -6,6 +6,7 @@ class DatePicker:
 
     def __init__(self, session: Session) -> None:
         self.root = Tk()
+        self.root.title("citrusHR")
         self.calendar = Calendar(self.root, selectmode='day')
         self.label = Label(self.root, text = "")
         self.session = session
@@ -47,6 +48,6 @@ class DatePicker:
         except Exception as e:
             self.label.config(text=f'Request failed with error: {e}')
 
-
     def quit(self):
         self.root.destroy()
+        


### PR DESCRIPTION
New feature to the calendar widget, allowing users to request work from home on multiple dates simultaneously.

Changes:
- Implemented the ability to select multiple dates by clicking on them in the calendar widget.
- Added logic to handle deselection of dates by clicking on them again.
- Implemented the backend logic to handle work from home requests for multiple selected dates.
- Updated the user interface to display selected dates and provide feedback on successful requests.